### PR TITLE
Combine AI smart switching with smart mon choices automatically and d…

### DIFF
--- a/include/constants/battle_ai.h
+++ b/include/constants/battle_ai.h
@@ -42,7 +42,7 @@
 #define AI_FLAG_HELP_PARTNER          (1 << 12)  // AI can try to help partner. If not set, will tend not to target partner
 #define AI_FLAG_PREFER_STATUS_MOVES   (1 << 13)  // AI gets a score bonus for status moves. Should be combined with AI_FLAG_CHECK_BAD_MOVE to prevent using only status moves
 #define AI_FLAG_STALL                 (1 << 14)  // AI stalls battle and prefers secondary damage/trapping/etc. TODO not finished
-#define AI_FLAG_SMART_SWITCHING       (1 << 15)  // AI includes a lot more switching checks
+#define AI_FLAG_SMART_SWITCHING       (1 << 15)  // AI includes a lot more switching checks. Automatically includes AI_FLAG_SMART_MON_CHOICES for better results.
 #define AI_FLAG_ACE_POKEMON           (1 << 16)  // AI has an Ace Pokemon. The last Pokemon in the party will not be used until it's the last one remaining.
 #define AI_FLAG_OMNISCIENT            (1 << 17)  // AI has full knowledge of player moves, abilities, hold items
 #define AI_FLAG_SMART_MON_CHOICES     (1 << 18)  // AI will make smarter decisions when choosing which mon to send out mid-battle and after a KO, which are separate decisions. Pairs very well with AI_FLAG_SMART_SWITCHING.

--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -175,6 +175,10 @@ static u32 GetAiFlags(u16 trainerId)
         flags |= AI_FLAG_DOUBLE_BATTLE;
     }
 
+    // Automatically add smart choice flag to smart switching to greatly improve its behavior
+    if (flags & AI_FLAG_SMART_SWITCHING)
+        flags |= AI_FLAG_SMART_MON_CHOICES;
+
     return flags;
 }
 

--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -1943,7 +1943,7 @@ u8 GetMostSuitableMonToSwitchInto(u32 battler, bool32 switchAfterMonKOd)
 
     // Split ideal mon decision between after previous mon KO'd (prioritize offensive options) and after switching active mon out (prioritize defensive options), and expand the scope of both.
     // Only use better mon selection if AI_FLAG_SMART_MON_CHOICES is set for the trainer.
-    if (AI_THINKING_STRUCT->aiFlags[battler] & AI_FLAG_SMART_MON_CHOICES)
+    if (AI_THINKING_STRUCT->aiFlags[battler] & AI_FLAG_SMART_MON_CHOICES && !(gBattleTypeFlags & BATTLE_TYPE_DOUBLE)) // Won't bother configuring this for double battles
     {
         bestMonId = GetBestMonIntegrated(party, firstId, lastId, battler, opposingBattler, battlerIn1, battlerIn2, switchAfterMonKOd);
         return bestMonId;


### PR DESCRIPTION
…isable smart mon choices in double battles. (#4405)

* AI_FLAG_SMART_SWITCHING  also sets AI_FLAG_SMART_MON_CHOICES

* Disable AI_FLAG_SMART_MON_CHOICES in doubles

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Images
<!-- Please provide with relevant GIFs or images to make it easier for reviewers to accept your PR quicker.-->
<!-- If it doesn't apply, feel free to remove this section. -->

## Issue(s) that this PR fixes
<!-- Format: "Fixes #2345, fixes #4523, fixes #2222." -->
<!-- If it doesn't apply, feel free to remove this section. -->

## **People who collaborated with me in this PR**
<!-- Please credit everyone else that contributed to this PR, be it code and/or assets. -->
<!-- Use their GitHub tag if they have one. -->
<!-- If it doesn't apply, feel free to remove this section. -->

## Feature(s) this PR does NOT handle:
<!-- If your PR contains any unfinished features that are not considered merge-blocking, please list them here for clarity so no one can forget. -->
<!-- If it doesn't apply, feel free to remove this section. -->

## **Discord contact info**
<!--- formatted as name#numbers, e.g. Lunos#4026 -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
