### PR TITLE
Inspire and Shock Threads

### DIFF
--- a/asm/macros/battle_script.inc
+++ b/asm/macros/battle_script.inc
@@ -1824,6 +1824,10 @@
 	various BS_ATTACKER, VARIOUS_TRY_ACTIVATE_SOULHEART
 	.endm
 
+	.macro tryactivateinspire battler:req
+	various \battler, VARIOUS_TRY_ACTIVATE_INSPIRE
+	.endm
+
 	.macro tryactivatefellstinger battler:req
 	various \battler, VARIOUS_TRY_ACTIVATE_FELL_STINGER
 	.endm

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -5489,6 +5489,7 @@ BattleScript_FaintAttacker::
 	cleareffectsonfaint BS_ATTACKER
 	tryactivatesoulheart
 	tryactivatereceiver BS_ATTACKER
+	tryactivateinspire BS_ATTACKER
 	trytrainerslidefirstdownmsg BS_ATTACKER
 	return
 
@@ -5504,6 +5505,7 @@ BattleScript_FaintTarget::
 	tryactivatefellstinger BS_ATTACKER
 	tryactivatesoulheart
 	tryactivatereceiver BS_TARGET
+	tryactivateinspire BS_TARGET
 	tryactivatemoxie BS_ATTACKER        @ and chilling neigh, as one ice rider
 	tryactivatebeastboost BS_ATTACKER
 	tryactivategrimneigh BS_ATTACKER    @ and as one shadow rider
@@ -8525,12 +8527,6 @@ BattleScript_ScriptingAbilityStatRaise::
 	printstring STRINGID_ATTACKERABILITYSTATRAISE
 	waitmessage B_WAIT_TIME_LONG
 	copybyte gBattlerAttacker, sSAVED_DMG
-	return
-
-BattleScript_InspireActivates::
-	call BattleScript_AbilityPopUp
-	setstatchanger STAT_ATK, 1, FALSE
-	setstatchanger STAT_SPATK, 1, FALSE
 	return
 
 BattleScript_WeakArmorActivates::

--- a/include/battle_scripts.h
+++ b/include/battle_scripts.h
@@ -518,7 +518,6 @@ extern const u8 BattleScript_Terastallization[];
 extern const u8 BattleScript_BoosterEnergyEnd2[];
 extern const u8 BattleScript_TeraShellDistortingTypeMatchups[];
 extern const u8 BattleScript_TeraFormChange[];
-extern const u8 BattleScript_InspireActivates[];
 
 // zmoves
 extern const u8 BattleScript_ZMoveActivateDamaging[];

--- a/include/constants/battle_script_commands.h
+++ b/include/constants/battle_script_commands.h
@@ -234,6 +234,7 @@
 #define VARIOUS_STORE_HEALING_WISH                   142
 #define VARIOUS_HIT_SWITCH_TARGET_FAILED             143
 #define VARIOUS_TRY_REVIVAL_BLESSING                 144
+#define VARIOUS_TRY_ACTIVATE_INSPIRE                 145
 
 // Cmd_manipulatedamage
 #define DMG_CHANGE_SIGN            0

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -9803,6 +9803,31 @@ static void Cmd_various(void)
         gBattleStruct->soulheartBattlerId = 0;
         break;
     }
+    case VARIOUS_TRY_ACTIVATE_INSPIRE:
+    {
+        VARIOUS_ARGS();
+        gBattlerAbility = BATTLE_PARTNER(battler);
+        i = GetBattlerAbility(gBattlerAbility);
+        if (!IsBattlerAlive(gBattlerAbility)
+        && (i == ABILITY_INSPIRE)
+        && IsBattlerAlive(gBattleScripting.battler)
+        && !NoAliveMonsForEitherParty()
+        && CompareStat(gBattleScripting.battler, STAT_ATK, MAX_STAT_STAGE, CMP_LESS_THAN)
+        && CompareStat(gBattleScripting.battler, STAT_SPATK, MAX_STAT_STAGE, CMP_LESS_THAN))
+            {
+                SET_STATCHANGER(STAT_SPATK, 1, FALSE);
+                PREPARE_STAT_BUFFER(gBattleTextBuff1, STAT_SPATK);
+                BattleScriptPushCursor();
+                gBattlescriptCurrInstr = BattleScript_ScriptingAbilityStatRaise;
+                return;
+                SET_STATCHANGER(STAT_ATK, 1, FALSE);
+                PREPARE_STAT_BUFFER(gBattleTextBuff1, STAT_ATK);
+                BattleScriptPushCursor();
+                gBattlescriptCurrInstr = BattleScript_ScriptingAbilityStatRaise;
+                return;
+            }
+               
+    }
     case VARIOUS_TRY_ACTIVATE_FELL_STINGER:
     {
         VARIOUS_ARGS();

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -1160,7 +1160,9 @@ void PrepareStringBattle(u16 stringId, u32 battler)
     else if (battlerAbility == ABILITY_SHOCK_THREADS && CompareStat(gBattlerTarget, STAT_SPEED, MAX_STAT_STAGE, CMP_LESS_THAN))
     {
         BattleScriptPushCursorAndCallback(BattleScript_ShockThreadsActivates);
-                gBattleMoveDamage = GetNonDynamaxMaxHP(battler) / 16;
+                
+                gBattlerAbility = battlerAbility;
+                gBattleMoveDamage = GetNonDynamaxMaxHP(gBattlerTarget) / 16;
                 if (gBattleMoveDamage == 0)
                         gBattleMoveDamage = 1;
     }
@@ -5511,17 +5513,6 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
              && !(gStatuses3[battler] & STATUS3_SKY_DROPPED))
             {
                 gBattleResources->flags->flags[battler] |= RESOURCE_FLAG_EMERGENCY_EXIT;
-                effect++;
-            }
-            break;
-        case ABILITY_INSPIRE:
-            partner = BATTLE_PARTNER(battler);
-            if ((gBattleMons[battler].hp == 0)
-            && IsBattlerAlive(partner)
-            && (CompareStat(partner, STAT_ATK, MAX_STAT_STAGE, CMP_LESS_THAN) || CompareStat(partner, STAT_SPATK, MAX_STAT_STAGE, CMP_LESS_THAN)))
-            {
-                BattleScriptPushCursor();
-                gBattlescriptCurrInstr = BattleScript_InspireActivates;
                 effect++;
             }
             break;


### PR DESCRIPTION
Moved Inspire logic to Battle_Script_Commands instead of Battle_Util so it can utilize the tryactivate functionality on a faint like Soul Heart and other abilities.

Updated Shock Threads logic to hopefully specify only the opposing side takes damage when speed is lowered. Will have to test.